### PR TITLE
rmi: unify sentinel arg reading + add frame-by-frame Decoder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,20 +55,25 @@ Key contracts:
 
 Read-only parser for a single direction of a JRMP Stream-protocol (`0x4B`) byte stream. Consumes either a client→server or server→client capture and produces a `Transmission` tree: optional `Handshake` (client side) or `Acknowledge` (server side), optional `ClientEndpoint` echo, then a `Messages []Message` list.
 
-**Two entry points, one parser.** Both `FromBytes(data []byte)` and `FromStream(r io.Reader)` delegate to the same `parseTransmission(stream, streaming bool)`. The `streaming` flag propagates down into `readCall` and `readReturn` and picks the arg-reading strategy; every other step (handshake, ack, primitive header via `readLeadingBlocks`, Registry decoder lookup) is shared.
-- `rmi.FromBytes(data []byte)` — buffered. Sentinel-based arg loop (reads TCContents until non-TC_* byte or `io.EOF`). Safe on any input that eventually EOFs; supports non-Registry calls and Return messages because EOF reliably terminates the sentinel.
-- `rmi.FromStream(io.Reader)` — streaming. Exact-count arg loop (reads exactly `registryArgCount(op)` TCContents). Won't block on a live reader between frames, but is deliberately narrower — see "streaming scope" below. Registry calls only; Return returns an error.
+**Three entry points, one parser.** `FromBytes(data []byte)`, `FromStream(r io.Reader)`, and `Decoder` (via `NewDecoder(r)` + `Opening()` + `Next()`) all delegate to the same underlying `readMessage` / `readOpening` primitives. No `streaming` flag on the core readers — each frame's arg strategy is picked from the frame's own header, not from the input source.
+- `rmi.FromBytes(data []byte)` — whole-Transmission, buffered input. Loops until `io.EOF`.
+- `rmi.FromStream(io.Reader)` — whole-Transmission, live input. Loops until the reader returns `io.EOF`. Blocks on the reader between frames; supports every frame type (not just Registry), with the blocking caveat documented in "Arg-reading strategy" below.
+- `rmi.Decoder` (`rmi/decoder.go`) — frame-by-frame, live input. `Opening()` reads the optional handshake prefix; `Next()` returns one `Message` per call or `io.EOF`. The idiomatic API for live `net.Conn` consumers who want to apply `SetReadDeadline` between frames.
 
-Both rely on `serz.NewObjectStreamFromStream(*commons.Stream)` so the embedded serialization parse shares a byte cursor with the outer framing reader — no double-buffering, no peeked-byte loss at handoff.
+Both streaming paths rely on `serz.NewObjectStreamFromStream(*commons.Stream)` so the embedded serialization parse shares a byte cursor with the outer framing reader — no double-buffering, no peeked-byte loss at handoff.
+
+**Arg-reading strategy inside `readCallArgs` / `readReturn`.**
+- *Registry fast path* (ObjID == `REGISTRY_ID` AND `methodHash == RegistryInterfaceHash` AND op ∈ [0..4]): exact-count via `registryArgCount(op)`. Reads precisely N TCContents and returns — no peek past the last arg, so the parser returns as soon as the frame's own bytes arrive. Critical for live TCP: a Registry client that sends one Call and waits for the server's response would deadlock any peek-ahead scheme.
+- *Sentinel fallback* (non-Registry Calls, ReturnData payloads): read TCContents until `PeekN(1)` yields a byte outside `[JAVA_TC_BASE, JAVA_TC_MAX]` (= `[0x70, 0x7F]`) or `io.EOF`. TC_* and JRMP-flag (`[0x50, 0x54]`) ranges are disjoint, so the check is unambiguous. **On a live reader the terminating peek blocks** until the next frame's flag byte arrives, the peer closes (`io.EOF`), or the reader's deadline fires. Callers that need responsiveness on non-Registry frames must set `SetReadDeadline` on the underlying `net.Conn`.
 
 Every JRMP frame implements `Message` (`Op() byte` + `ToString() string`). Five frame types:
 
-- **`CallMessage`** (0x50) — wraps an embedded serialization stream. The first `TC_BLOCKDATA` holds 34 bytes of primitive writes (`ObjID(22) + int32 op + int64 methodHash`). Remaining `TCContent` entries are `writeObject` arguments. `Decoded` is filled when `ObjID.IsRegistry()` **and** `methodHash == RegistryInterfaceHash`, dispatching via the int32 op-index (see Registry note below); otherwise `Raw` and `ObjectArgs` hold the untouched tree. `ToString()` renders the stream in wireshark-dissector style — see the rendering note below.
+- **`CallMessage`** (0x50) — wraps an embedded serialization stream. The first `TC_BLOCKDATA` holds 34 bytes of primitive writes (`ObjID(22) + int32 op + int64 methodHash`). Remaining `TCContent` entries are `writeObject` arguments. `Decoded` is filled when `ObjID.IsRegistry()` **and** `methodHash == RegistryInterfaceHash` **and** the op-index is one of the five known Registry ops; otherwise `Raw` and `ObjectArgs` hold the untouched tree. `ToString()` renders the stream in wireshark-dissector style — see the rendering note below.
 - **`ReturnMessage`** (0x51) — same embedded-stream shape, 15 bytes of primitives (`returnType + UID`) then ≤1 payload `TCContent` (value / exception / none-for-void).
 - **`PingMessage`** (0x52), **`PingAckMessage`** (0x53) — single-byte frames, no payload.
 - **`DgcAckMessage`** (0x54) — raw 14-byte UID written outside any `ObjectOutputStream` framing (the only JRMP frame that does *not* go through `serz`).
 
-**The critical design point worth internalizing**: a single Java serialization stream has no explicit end marker — `serz.FromReader` terminates only on `io.EOF`. Inside JRMP, the next byte after a Call/Return body is the next message's flag (`0x50..0x54`), which is neither `io.EOF` nor a valid `TC_*` tag. The buffered-mode branches of `readCallArgs` (`rmi/call.go`) and `readReturn` (`rmi/return.go`) walk `serz.ReadTCContent` in a loop and stop when `PeekN(1)` returns a byte outside `[serz.JAVA_TC_BASE, serz.JAVA_TC_MAX]` = `[0x70, 0x7F]`. TC_* and JRMP-flag ranges are disjoint, so the check is unambiguous. **Do not refactor this to use `serz.FromBytes`** — doing so would fail on any stream with more than one frame.
+**The critical design point worth internalizing**: a single Java serialization stream has no explicit end marker — `serz.FromReader` terminates only on `io.EOF`. Inside JRMP, the next byte after a Call/Return body is the next message's flag (`0x50..0x54`), which is neither `io.EOF` nor a valid `TC_*` tag. The sentinel branches of `readCallArgs` (`rmi/call.go`) and `readReturn` (`rmi/return.go`) walk `serz.ReadTCContent` in a loop and stop when `PeekN(1)` returns a byte outside `[serz.JAVA_TC_BASE, serz.JAVA_TC_MAX]` = `[0x70, 0x7F]`. **Do not refactor this to use `serz.FromBytes`** — doing so would fail on any stream with more than one frame.
 
 **Registry dispatch is op-index + interface hash, not per-method hash.** The JDK ships a precompiled `sun.rmi.registry.RegistryImpl_Stub` whose wire format is `operation = 0..4` (indexing into `{bind, list, lookup, rebind, unbind}`) paired with a single `int64 RegistryInterfaceHash` shared by all five methods. Modern JRMP's `operation = -1 + per-method hash` pattern applies only to dynamic-proxy stubs and is NOT used by Registry. `rmi/model.go` exposes the five op-index constants (`LookupOpIndex`, etc.) and the `RegistryInterfaceHash` constant (calibrated against a live Zulu OpenJDK 17 capture; see `testcases/rmi/*.bin` and `_tools/rmi-capture/`). If a real capture's `CallMessage.Decoded` is nil for an obvious Registry call, print `MethodHash` as hex and compare — recalibration is a one-line edit.
 
@@ -76,13 +81,25 @@ Adding a new message type (e.g. if SingleOp/Multiplex support is ever added): ex
 
 The endpoint-echo heuristic in `parser.go:maybeReadClientEndpoint` peeks the byte right after the handshake: if it falls in `[0x50, 0x54]` (JRMP message flag range) we skip the echo, otherwise read `writeUTF + int32`. This lets hand-crafted test fixtures omit the echo. The ambiguity only collides on pathological (≥ 20480-char) hostnames.
 
-**Streaming scope (`FromStream`).** A live TCP reader doesn't EOF at a message boundary — it just waits for the next byte that may never come. The sentinel approach `FromBytes` uses (loop `ReadTCContent` until `PeekN` returns a non-`TC_*` byte) would block forever on such a reader. `FromStream` instead derives each Call's arg count from the method's protocol signature and reads exactly that many TCContents — self-delimiting TCContent parsing guarantees the byte boundary is exact. This requires external schema for arbitrary Remote interfaces, which we don't have, so:
-- **Registry Calls** (ObjID == `REGISTRY_ID` AND `MethodHash == RegistryInterfaceHash`): `registryArgCount(op)` returns the known `{bind:2, list:0, lookup:1, rebind:2, unbind:1}`; streaming parser reads exactly that many.
-- **Non-Registry Calls**: deliberately return an error. Buffer the stream and use `FromBytes` for full parsing.
-- **ReturnData (0x51)**: not supported in streaming mode either — a `NormalReturn`'s 0-vs-1 payload count depends on the originating Call's return type, which requires call/response correlation we don't track. Error and direct caller to `FromBytes`.
-- **Handshake / Acknowledge / Ping / PingAck / DgcAck**: all bounded-length frames, always supported.
+**Live-TCP ergonomics.** `FromStream` loops internally until `io.EOF` — fine for bounded streams (`io.Pipe`, `bytes.Reader`) but a trap on a long-lived `net.Conn` where the peer keeps the connection open between frames. For live connections, use `Decoder` (`rmi/decoder.go`):
 
-`serz.NewObjectStreamFromStream(s *commons.Stream) *ObjectStream` is the primitive both modes stand on — it lets an embedded serialization parse share a `commons.Stream` byte cursor with its caller, avoiding the double-buffering trap where bytes peeked into one layer get lost at handoff.
+```go
+d := rmi.NewDecoder(conn)
+opening, _ := d.Opening()       // optional — read handshake/ack/endpoint
+for {
+    _ = conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+    msg, err := d.Next()
+    if errors.Is(err, io.EOF) { break }
+    if err != nil { return err }
+    handle(msg)
+}
+```
+
+`Decoder.Next()` returns one frame per call. Registry Calls return as soon as their own bytes arrive (exact count, no peek past last arg). Non-Registry Calls and ReturnData use the sentinel, which blocks after the last arg/payload until either the next frame's flag byte arrives or the reader returns an error (EOF, read timeout from `SetReadDeadline`, etc.). The caller is responsible for configuring the deadline appropriate to their workload — the parser doesn't invent one.
+
+`Opening()` is optional; if omitted, the first `Next()` transparently consumes and discards any handshake prefix. Calling `Opening()` twice, or after `Next()`, returns an error.
+
+`serz.NewObjectStreamFromStream(s *commons.Stream) *ObjectStream` is the primitive all three entry points stand on — it lets an embedded serialization parse share a `commons.Stream` byte cursor with its caller, avoiding the double-buffering trap where bytes peeked into one layer get lost at handoff.
 
 **`ToString()` rendering is wireshark-dissector style — every byte is printed exactly once, with semantic labels inline.** `Call/ReturnMessage.ToString()` emits a compact `@Decoded` summary (method + scalar args; complex args referenced by handler) at the top, then `@Serialization` with a custom walk (`rmi/printer.go`):
 

--- a/rmi/call.go
+++ b/rmi/call.go
@@ -46,20 +46,23 @@ func (c *CallMessage) ToString() string {
 
 // readCall consumes one MsgCall frame starting at the 0x50 flag byte.
 //
-// Two arg-reading strategies share everything above the arg loop:
+// The arg reader picks one of two strategies based on what the header tells
+// us about the Call:
 //
-//   - streaming == false (buffered input like *.bin / bytes.Reader): sentinel
-//     — read TCContents until PeekN yields a non-TC_* byte or io.EOF. The
-//     sentinel relies on EOF or a next-frame flag (0x50..0x54) terminating
-//     the loop; safe on any input that eventually EOFs, would block forever
-//     on a live TCP reader.
+//   - Exact count (Registry fast path): when ObjID == REGISTRY_ID,
+//     hash == RegistryInterfaceHash, and op ∈ [0..4], we look up the stub's
+//     arg count via registryArgCount(op) and read precisely that many
+//     TCContents. No PeekN past the last arg, so the parser returns the
+//     frame as soon as its own bytes arrive — even on a live TCP reader
+//     where the peer is about to wait for a response before sending more.
 //
-//   - streaming == true (live io.Reader like net.Conn): exact count — we
-//     require a Registry call (ObjID=REGISTRY_ID + hash=RegistryInterfaceHash),
-//     look up the stub's arg count via registryArgCount(op), and read
-//     precisely that many TCContents. No PeekN past the last arg means no
-//     blocking on "maybe more bytes".
-func readCall(outer *commons.Stream, streaming bool) (*CallMessage, error) {
+//   - Sentinel (fallback): read TCContents until PeekN yields a non-TC_*
+//     byte or io.EOF. Correct on any input, but the peek after the last arg
+//     blocks on a live reader until the next frame's flag byte arrives, the
+//     peer closes (io.EOF), or the reader's deadline fires. Callers that
+//     need responsiveness on non-Registry Calls should set SetReadDeadline
+//     on their net.Conn.
+func readCall(outer *commons.Stream) (*CallMessage, error) {
 	flagBs, err := outer.ReadN(1)
 	if err != nil {
 		return nil, fmt.Errorf("read Call flag on index %v: %w", outer.CurrentIndex(), err)
@@ -105,7 +108,7 @@ func readCall(outer *commons.Stream, streaming bool) (*CallMessage, error) {
 	op := int32(binary.BigEndian.Uint32(primitive[objIDLen : objIDLen+4]))
 	hash := int64(binary.BigEndian.Uint64(primitive[objIDLen+4 : callPrimitiveLen]))
 
-	args, err := readCallArgs(inner, streaming, objID, op, hash)
+	args, err := readCallArgs(inner, objID, op, hash)
 	if err != nil {
 		return nil, err
 	}
@@ -164,32 +167,34 @@ func readLeadingBlocks(inner *serz.ObjectStream, want int) ([]*serz.TCContent, [
 	return blocks, primitive, nil
 }
 
-// readCallArgs returns the object-arg TCContents of a Call. Buffered mode
-// sentinel-scans until non-TC_* / EOF; streaming mode requires a Registry
-// call and reads exactly registryArgCount(op) contents.
-func readCallArgs(inner *serz.ObjectStream, streaming bool, objID ObjID, op int32, hash int64) ([]*serz.TCContent, error) {
-	if streaming {
-		if !objID.IsRegistry() || hash != RegistryInterfaceHash {
-			return nil, fmt.Errorf("streaming parser only supports Registry calls (ObjID=REGISTRY_ID + hash=RegistryInterfaceHash); "+
-				"got ObjNum=%d hash=0x%X — buffer the full stream and use FromBytes for non-Registry remotes",
-				objID.ObjNum, hash)
-		}
-		argCount, ok := registryArgCount(op)
-		if !ok {
-			return nil, fmt.Errorf("streaming parser only supports known Registry op-indices [0..4]; got op=%d", op)
-		}
-		args := make([]*serz.TCContent, 0, argCount)
-		for i := 0; i < argCount; i++ {
-			content, err := serz.ReadTCContent(inner)
-			if err != nil {
-				return nil, fmt.Errorf("read Call arg %d: %w", i, err)
+// readCallArgs returns the object-arg TCContents of a Call.
+//
+// Fast path: a conforming Registry call (matching ObjID + interface hash +
+// known op-index) has a well-defined arg count, so we read exactly that many
+// and return — no peek past the last arg, no blocking on a live reader
+// waiting for "maybe more bytes".
+//
+// Fallback: for any other Call we don't know the method signature, so we
+// fall back to a sentinel scan (read TCContents until PeekN yields a byte
+// outside the TC_* range or io.EOF). The sentinel's terminating peek blocks
+// on a live reader until the next frame's flag byte arrives, the peer
+// closes, or the reader's deadline fires.
+func readCallArgs(inner *serz.ObjectStream, objID ObjID, op int32, hash int64) ([]*serz.TCContent, error) {
+	if objID.IsRegistry() && hash == RegistryInterfaceHash {
+		if argCount, ok := registryArgCount(op); ok {
+			args := make([]*serz.TCContent, 0, argCount)
+			for i := 0; i < argCount; i++ {
+				content, err := serz.ReadTCContent(inner)
+				if err != nil {
+					return nil, fmt.Errorf("read Call arg %d: %w", i, err)
+				}
+				args = append(args, content)
 			}
-			args = append(args, content)
+			return args, nil
 		}
-		return args, nil
 	}
 
-	// Buffered sentinel: stop on next-frame flag or EOF.
+	// Sentinel: stop on next-frame flag or EOF.
 	var args []*serz.TCContent
 	for {
 		next, err := inner.PeekN(1)

--- a/rmi/decoder.go
+++ b/rmi/decoder.go
@@ -1,0 +1,114 @@
+package rmi
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/phith0n/zkar/commons"
+)
+
+// Decoder reads a JRMP byte stream frame-by-frame from an io.Reader (e.g. a
+// live net.Conn). Unlike FromStream — which loops internally until the
+// reader EOFs — Decoder returns each frame as soon as it's parsed, so
+// callers can process one message before the next arrives, and can apply
+// SetReadDeadline on the underlying net.Conn between calls to bound how
+// long they wait for the next frame.
+//
+// Blocking semantics: Decoder is subject to the same between-frame peek
+// that FromStream is. The Registry fast path (matching ObjID + interface
+// hash + known op-index) reads an exact arg count and returns as soon as
+// its own bytes arrive. A non-Registry Call or a ReturnData uses a sentinel
+// peek after its last arg/payload that blocks until one of:
+//
+//   - the next frame's flag byte arrives → current frame returns
+//   - the peer closes the connection → current frame returns; the NEXT
+//     Next() call returns io.EOF
+//   - the reader's deadline fires → Next() returns the deadline error;
+//     the parse state is preserved, so after SetReadDeadline is extended
+//     the caller MAY retry. In practice most deadline errors from net.Conn
+//     are terminal (the timeout unblocks all outstanding reads); retry is
+//     only safe if you can reason about your deadline/connection state.
+//
+// Typical usage:
+//
+//	d := rmi.NewDecoder(conn)
+//	opening, err := d.Opening()          // optional; omit to skip
+//	if err != nil { return err }
+//	for {
+//	    _ = conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+//	    msg, err := d.Next()
+//	    if errors.Is(err, io.EOF) { break }
+//	    if err != nil { return err }
+//	    handle(msg)
+//	}
+type Decoder struct {
+	stream      *commons.Stream
+	openingDone bool
+}
+
+// NewDecoder returns a Decoder that reads from r. The Decoder holds the
+// reader until its last frame is consumed or the caller drops it; the
+// underlying bytes are only consumed on Opening() / Next() calls.
+func NewDecoder(r io.Reader) *Decoder {
+	return &Decoder{stream: commons.NewStreamFromReader(r)}
+}
+
+// Opening reads the optional handshake-phase prefix: Handshake + client
+// endpoint echo (client→server direction) or Acknowledge (server→client
+// direction), or neither for a bare capture that starts mid-stream.
+//
+// Calling Opening is optional — if the caller omits it, the first Next()
+// call will read and discard any opening transparently. Explicit Opening
+// is the way to access the Handshake / Acknowledge / ClientEndpoint fields.
+//
+// It is an error to call Opening twice, or to call it after Next().
+func (d *Decoder) Opening() (*Opening, error) {
+	if d.openingDone {
+		return nil, errors.New("rmi.Decoder: Opening already called")
+	}
+	d.openingDone = true
+	var t Transmission
+	if err := readOpening(d.stream, &t); err != nil {
+		return nil, err
+	}
+	return &Opening{
+		Handshake:      t.Handshake,
+		Acknowledge:    t.Acknowledge,
+		ClientEndpoint: t.ClientEndpoint,
+	}, nil
+}
+
+// Next returns the next JRMP message. On the first call, if Opening hasn't
+// been invoked, any handshake prefix is read and discarded. Returns io.EOF
+// when the reader closes cleanly at a frame boundary. For non-Registry
+// Calls and ReturnData, see the Decoder doc for blocking semantics.
+func (d *Decoder) Next() (Message, error) {
+	if !d.openingDone {
+		var discard Transmission
+		if err := readOpening(d.stream, &discard); err != nil {
+			return nil, err
+		}
+		d.openingDone = true
+	}
+	if _, err := d.stream.PeekN(1); err != nil {
+		// io.EOF flows through unwrapped so callers can check with
+		// errors.Is(err, io.EOF); other errors (read timeouts, etc.)
+		// are wrapped for context.
+		if errors.Is(err, io.EOF) {
+			return nil, io.EOF
+		}
+		return nil, fmt.Errorf("peek next message: %w", err)
+	}
+	return readMessage(d.stream)
+}
+
+// Opening captures the three optional handshake-phase fields of a JRMP
+// Transmission. Any or all may be nil: client→server traffic typically sets
+// Handshake + ClientEndpoint; server→client sets Acknowledge; a capture
+// that starts mid-session sets none.
+type Opening struct {
+	Handshake      *Handshake
+	Acknowledge    *Acknowledge
+	ClientEndpoint *Endpoint
+}

--- a/rmi/decoder_test.go
+++ b/rmi/decoder_test.go
@@ -1,0 +1,200 @@
+package rmi
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDecoderFrameByFrame: Decoder yields one Message per Next() call,
+// reports io.EOF at the end, and preserves the ordering of a handshake +
+// Call + Ping + DgcAck sequence.
+func TestDecoderFrameByFrame(t *testing.T) {
+	var buf bytes.Buffer
+	buf.Write(buildHandshake())
+	buf.Write(buildClientEndpointEcho("h", 1))
+	buf.Write(buildCall(ObjID{}, LookupOpIndex, RegistryInterfaceHash, buildTCString("svc")))
+	buf.Write(buildPing())
+	buf.Write(buildDgcAck(UID{Unique: 7, Time: 8, Count: 9}))
+
+	d := NewDecoder(&buf)
+
+	opening, err := d.Opening()
+	require.NoError(t, err)
+	require.NotNil(t, opening.Handshake)
+	require.NotNil(t, opening.ClientEndpoint)
+	require.Nil(t, opening.Acknowledge)
+
+	m1, err := d.Next()
+	require.NoError(t, err)
+	require.Equal(t, MsgCall, m1.Op())
+	call := m1.(*CallMessage)
+	require.Equal(t, "Registry.lookup", call.Decoded.Method)
+	require.Equal(t, "svc", call.Decoded.Args[0].Value)
+
+	m2, err := d.Next()
+	require.NoError(t, err)
+	require.Equal(t, MsgPing, m2.Op())
+
+	m3, err := d.Next()
+	require.NoError(t, err)
+	require.Equal(t, MsgDgcAck, m3.Op())
+
+	_, err = d.Next()
+	require.True(t, errors.Is(err, io.EOF))
+}
+
+// TestDecoderSkipsOpeningWhenOmitted: calling Next() without first calling
+// Opening() should transparently consume and discard any handshake prefix.
+func TestDecoderSkipsOpeningWhenOmitted(t *testing.T) {
+	var buf bytes.Buffer
+	buf.Write(buildHandshake())
+	buf.Write(buildClientEndpointEcho("h", 1))
+	buf.Write(buildPing())
+
+	d := NewDecoder(&buf)
+	msg, err := d.Next()
+	require.NoError(t, err)
+	require.Equal(t, MsgPing, msg.Op())
+}
+
+// TestDecoderOpeningTwiceErrors: Opening() is a once-only operation.
+func TestDecoderOpeningTwiceErrors(t *testing.T) {
+	d := NewDecoder(bytes.NewReader(buildHandshake()))
+	_, err := d.Opening()
+	require.NoError(t, err)
+	_, err = d.Opening()
+	require.Error(t, err)
+}
+
+// TestDecoderOpeningAfterNextErrors: once Next() has been called, Opening()
+// may no longer be called.
+func TestDecoderOpeningAfterNextErrors(t *testing.T) {
+	var buf bytes.Buffer
+	buf.Write(buildPing())
+	d := NewDecoder(&buf)
+	_, err := d.Next()
+	require.NoError(t, err)
+	_, err = d.Opening()
+	require.Error(t, err)
+}
+
+// TestDecoderBareCaptureNoOpening: a capture that starts mid-stream (no
+// handshake, no ack) must work — Opening() returns a zero-value Opening
+// and consumes nothing.
+func TestDecoderBareCaptureNoOpening(t *testing.T) {
+	d := NewDecoder(bytes.NewReader(buildPing()))
+	opening, err := d.Opening()
+	require.NoError(t, err)
+	require.Nil(t, opening.Handshake)
+	require.Nil(t, opening.Acknowledge)
+	require.Nil(t, opening.ClientEndpoint)
+
+	msg, err := d.Next()
+	require.NoError(t, err)
+	require.Equal(t, MsgPing, msg.Op())
+}
+
+// TestDecoderRegistryCallReturnsWithoutPeek: the Registry fast path reads
+// exactly N args, so Decoder returns the frame as soon as the frame's own
+// bytes arrive — we don't wait for any byte of a (nonexistent) next frame.
+// Using io.Pipe with no Close after the final byte proves this: if the
+// Decoder tried to peek ahead, the test would deadlock.
+func TestDecoderRegistryCallReturnsWithoutPeek(t *testing.T) {
+	data := loadRMIFixture(t, "jdk17", "lookup-c2s.bin")
+	pr, pw := io.Pipe()
+
+	// Writer feeds the exact Call bytes and then sits idle — it never closes
+	// and never writes a next frame. If the parser peeks past the last arg,
+	// the test deadlocks and the 2s timeout fires.
+	go func() {
+		_, _ = pw.Write(data)
+		// Intentional: no Close. Simulates a live client that sent one Call
+		// and is now waiting for the server's response.
+	}()
+
+	type result struct {
+		msg Message
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		d := NewDecoder(pr)
+		_, openingErr := d.Opening()
+		if openingErr != nil {
+			done <- result{nil, openingErr}
+			return
+		}
+		m, e := d.Next()
+		done <- result{m, e}
+	}()
+
+	select {
+	case r := <-done:
+		require.NoError(t, r.err)
+		require.Equal(t, MsgCall, r.msg.Op())
+	case <-time.After(2 * time.Second):
+		// Close the pipe so the goroutine can exit after we fail.
+		_ = pw.CloseWithError(io.EOF)
+		t.Fatal("Decoder.Next blocked past the last byte of a Registry Call — the exact-count fast path should have returned without peeking")
+	}
+}
+
+// TestDecoderNonRegistryCallBlocksOnSentinelPeek: for a non-Registry Call
+// we fall back to the sentinel, which peeks the byte after the last arg.
+// On a live reader with no follow-up bytes, that peek blocks — documenting
+// the Decoder's contract: callers must close the reader, send the next
+// frame, or set a deadline to unblock.
+//
+// The test asserts both halves: (a) a short timeout fires while blocked,
+// confirming the parser *is* waiting; (b) closing the writer end with
+// io.EOF afterwards lets the parser return successfully, confirming the
+// block is a peek-wait and not a bug.
+func TestDecoderNonRegistryCallBlocksOnSentinelPeek(t *testing.T) {
+	nonReg := ObjID{ObjNum: 42, UID: UID{Unique: 1, Time: 2, Count: 3}}
+	data := buildCall(nonReg, LookupOpIndex, RegistryInterfaceHash, buildTCString("x"))
+	pr, pw := io.Pipe()
+
+	go func() {
+		_, _ = pw.Write(data)
+		// Keep writer open: mimics a live connection where the peer has sent
+		// one Call and is waiting. The Decoder's sentinel peek has nothing
+		// to read and must block.
+	}()
+
+	type result struct {
+		msg Message
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		d := NewDecoder(pr)
+		m, e := d.Next()
+		done <- result{m, e}
+	}()
+
+	// (a) Confirm it blocks while the pipe is open.
+	select {
+	case r := <-done:
+		t.Fatalf("Decoder.Next returned before the pipe was closed (msg=%v err=%v) — non-Registry Call should block on sentinel peek", r.msg, r.err)
+	case <-time.After(150 * time.Millisecond):
+		// Expected: still blocked.
+	}
+
+	// (b) Close the writer → sentinel peek gets io.EOF → Decoder returns.
+	require.NoError(t, pw.Close())
+
+	select {
+	case r := <-done:
+		require.NoError(t, r.err)
+		require.Equal(t, MsgCall, r.msg.Op())
+		call := r.msg.(*CallMessage)
+		require.Len(t, call.ObjectArgs, 1)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Decoder.Next failed to return after pipe close")
+	}
+}

--- a/rmi/message.go
+++ b/rmi/message.go
@@ -13,19 +13,19 @@ type Message interface {
 }
 
 // readMessage peeks the next byte and dispatches to the matching reader.
-// `streaming` picks the arg-reading strategy for Call (exact-count-for-
-// Registry vs sentinel) and the gating for Return (refused in streaming
-// mode because payload count needs call/response correlation we don't keep).
-func readMessage(outer *commons.Stream, streaming bool) (Message, error) {
+// Works identically for buffered and streaming input — the per-reader arg
+// strategies (exact-count-for-Registry vs sentinel) are chosen internally
+// based on each frame's header, not on the input source.
+func readMessage(outer *commons.Stream) (Message, error) {
 	next, err := outer.PeekN(1)
 	if err != nil {
 		return nil, err
 	}
 	switch next[0] {
 	case MsgCall:
-		return readCall(outer, streaming)
+		return readCall(outer)
 	case MsgReturnData:
-		return readReturn(outer, streaming)
+		return readReturn(outer)
 	case MsgPing:
 		return readPing(outer)
 	case MsgPingAck:

--- a/rmi/parser.go
+++ b/rmi/parser.go
@@ -35,82 +35,35 @@ type Transmission struct {
 }
 
 // FromBytes parses a fully-buffered JRMP byte slice (a .ser-style capture,
-// an io.ReadAll result, etc.). The buffered parser uses a sentinel-based
-// arg loop that terminates on io.EOF or a next-frame flag — safe on any
-// input that eventually reaches EOF, but would block forever on a live
-// reader that keeps the connection open between frames. For live streams
-// (net.Conn, pipes) use FromStream instead.
+// an io.ReadAll result, etc.). The parser loops readMessage until io.EOF,
+// returning the full Transmission.
 func FromBytes(data []byte) (*Transmission, error) {
-	return parseTransmission(commons.NewStream(data), false)
+	return parseTransmission(commons.NewStream(data))
 }
 
-// FromStream parses JRMP traffic from a live io.Reader (e.g. net.Conn)
-// without io.ReadAll-ing the whole stream first. Each message's byte
-// boundary is derived from protocol framing alone, so the parser won't
-// block on an idle connection after finishing one message but before the
-// next arrives.
+// FromStream parses JRMP traffic from an io.Reader (net.Conn, io.Pipe, etc.)
+// without io.ReadAll-ing the whole stream first. It loops readMessage until
+// the reader returns io.EOF, so every frame type is supported.
 //
-// Scope (intentionally narrow):
+// Blocking semantics: the message loop blocks on the reader between frames.
+// Inside a Call/Return, the Registry fast path returns as soon as its own
+// bytes arrive; a non-Registry Call or a Return uses a sentinel that blocks
+// after the last arg/payload until the next frame's flag byte arrives, the
+// peer closes the connection (io.EOF), or the reader's deadline fires.
 //
-//   - Handshake / Acknowledge / ClientEndpoint echo — bounded reads, fine.
-//   - MsgCall — supported ONLY for java.rmi.registry.Registry (ObjID ==
-//     REGISTRY_ID AND methodHash == RegistryInterfaceHash). Registry's
-//     op-index yields exact arg count via registryArgCount; non-Registry
-//     Calls return an error because we cannot know their arg count without
-//     external method-signature info.
-//   - MsgPing / MsgPingAck / MsgDgcAck — bounded, always supported.
-//   - MsgReturnData — not supported. NormalReturn's 0-vs-1 payload count
-//     needs call/response correlation we don't track; use FromBytes on a
-//     buffered copy of the full conversation for return parsing.
-//
-// Loop exits on io.EOF (caller closed the reader) or the first error from
-// a message reader.
+// For live TCP servers that need to process frames as they arrive — or for
+// any caller that wants to apply a SetReadDeadline between frames — use
+// Decoder instead; its Next() method returns one message at a time.
 func FromStream(r io.Reader) (*Transmission, error) {
-	return parseTransmission(commons.NewStreamFromReader(r), true)
+	return parseTransmission(commons.NewStreamFromReader(r))
 }
 
 // parseTransmission is the single implementation behind both FromBytes and
-// FromStream. The `streaming` flag propagates down into readCall / readReturn
-// where it picks the arg-reading strategy.
-func parseTransmission(stream *commons.Stream, streaming bool) (*Transmission, error) {
+// FromStream.
+func parseTransmission(stream *commons.Stream) (*Transmission, error) {
 	t := &Transmission{}
-
-	// Direction-agnostic opening: peek the first byte to decide what (if
-	// anything) precedes the message loop.
-	first, err := stream.PeekN(1)
-	if err != nil {
-		if errors.Is(err, io.EOF) {
-			return t, nil // empty input is a (degenerate) valid Transmission
-		}
-		return nil, fmt.Errorf("peek first byte: %w", err)
-	}
-
-	switch first[0] {
-	case JRMI_MAGIC[0]: // 0x4A — client→server handshake
-		h, herr := readHandshake(stream)
-		if herr != nil {
-			return nil, herr
-		}
-		t.Handshake = h
-
-		// A conforming Stream-protocol client immediately follows the
-		// 7-byte handshake with its own endpoint suggestion. Some
-		// hand-crafted fixtures skip this; peek and decide.
-		ep, eerr := maybeReadClientEndpoint(stream)
-		if eerr != nil {
-			return nil, fmt.Errorf("client endpoint echo: %w", eerr)
-		}
-		t.ClientEndpoint = ep
-
-	case AckFlag: // 0x4E — server→client ProtocolAck
-		a, aerr := readAcknowledge(stream)
-		if aerr != nil {
-			return nil, aerr
-		}
-		t.Acknowledge = a
-
-		// No further server-side echo: Acknowledge already carries
-		// the server's view of the client endpoint.
+	if err := readOpening(stream, t); err != nil {
+		return nil, err
 	}
 
 	// Message loop until EOF.
@@ -122,12 +75,57 @@ func parseTransmission(stream *commons.Stream, streaming bool) (*Transmission, e
 			}
 			return nil, fmt.Errorf("peek next message: %w", err)
 		}
-		msg, merr := readMessage(stream, streaming)
+		msg, merr := readMessage(stream)
 		if merr != nil {
 			return nil, merr
 		}
 		t.Messages = append(t.Messages, msg)
 	}
+}
+
+// readOpening consumes the optional handshake-phase prefix (handshake OR
+// acknowledge, plus the client's endpoint echo when a handshake is present).
+// It peeks the first byte to decide what — if anything — precedes the
+// message loop. Populates the given Transmission's Handshake / Acknowledge /
+// ClientEndpoint fields in place. An empty (EOF) stream is a (degenerate)
+// valid Transmission and leaves t untouched.
+func readOpening(stream *commons.Stream, t *Transmission) error {
+	first, err := stream.PeekN(1)
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		return fmt.Errorf("peek first byte: %w", err)
+	}
+
+	switch first[0] {
+	case JRMI_MAGIC[0]: // 0x4A — client→server handshake
+		h, herr := readHandshake(stream)
+		if herr != nil {
+			return herr
+		}
+		t.Handshake = h
+
+		// A conforming Stream-protocol client immediately follows the
+		// 7-byte handshake with its own endpoint suggestion. Some
+		// hand-crafted fixtures skip this; peek and decide.
+		ep, eerr := maybeReadClientEndpoint(stream)
+		if eerr != nil {
+			return fmt.Errorf("client endpoint echo: %w", eerr)
+		}
+		t.ClientEndpoint = ep
+
+	case AckFlag: // 0x4E — server→client ProtocolAck
+		a, aerr := readAcknowledge(stream)
+		if aerr != nil {
+			return aerr
+		}
+		t.Acknowledge = a
+
+		// No further server-side echo: Acknowledge already carries
+		// the server's view of the client endpoint.
+	}
+	return nil
 }
 
 // maybeReadClientEndpoint reads the client's post-handshake endpoint echo

--- a/rmi/return.go
+++ b/rmi/return.go
@@ -38,18 +38,19 @@ func (r *ReturnMessage) ToString() string {
 	return b.String()
 }
 
-// readReturn consumes one MsgReturnData frame. In streaming mode we refuse
-// immediately: a NormalReturn's 0-vs-1 payload count depends on the
-// originating Call's return type, and we don't track call/response state.
-// Buffered mode uses a sentinel payload read (0 or 1 TCContent) — the sentinel
-// works there because the input eventually EOFs.
-func readReturn(outer *commons.Stream, streaming bool) (*ReturnMessage, error) {
-	if streaming {
-		return nil, fmt.Errorf("streaming parser does not support ReturnData (0x51) on index %v: "+
-			"void-vs-value payload requires call/response correlation; buffer the stream and use FromBytes instead",
-			outer.CurrentIndex())
-	}
-
+// readReturn consumes one MsgReturnData frame.
+//
+// A ReturnData carries 0 or 1 payload TCContent after the 15-byte primitive
+// header — 0 for void methods, 1 for value/exception returns. Which of the
+// two depends on the originating Call's return type, which we don't track.
+// We use a sentinel payload read: keep reading TCContents until PeekN yields
+// a byte outside the TC_* range or io.EOF, assert the count is ≤ 1.
+//
+// On a live reader this means the peek after the payload (or after the
+// header, for a void return) blocks until the next frame's flag byte
+// arrives, the peer closes, or the reader's deadline fires. Callers that
+// need responsiveness should set SetReadDeadline on their net.Conn.
+func readReturn(outer *commons.Stream) (*ReturnMessage, error) {
 	flagBs, err := outer.ReadN(1)
 	if err != nil {
 		return nil, fmt.Errorf("read ReturnData flag on index %v: %w", outer.CurrentIndex(), err)

--- a/rmi/streaming_test.go
+++ b/rmi/streaming_test.go
@@ -10,11 +10,10 @@ import (
 )
 
 // TestStreamParsesRealCaptures runs FromStream against every real rmiregistry
-// client→server capture. Because FromStream reads exactly each message's
-// bytes (no sentinel peek at end-of-Call), feeding the exact .bin payload
-// via bytes.NewReader is the key regression: if the streaming Call reader
-// ever over-reads, it would hit io.ErrUnexpectedEOF mid-frame and fail
-// here.
+// client→server capture. Registry Calls use the exact-count fast path, so
+// feeding the exact .bin payload via bytes.NewReader — no trailing bytes —
+// must parse cleanly without the parser over-reading and hitting
+// io.ErrUnexpectedEOF mid-frame.
 func TestStreamParsesRealCaptures(t *testing.T) {
 	cases := []struct {
 		op       string
@@ -62,50 +61,85 @@ func TestStreamHandshakeOnly(t *testing.T) {
 	require.Empty(t, tr.Messages)
 }
 
-// TestStreamRejectsNonRegistryCall: the ObjID is non-zero (not Registry),
-// so we can't know the method's arg count without external schema. The
-// streaming parser must error out instead of guessing.
-func TestStreamRejectsNonRegistryCall(t *testing.T) {
+// TestStreamNonRegistryCall: a Call whose ObjID is not REGISTRY_ID (so no
+// exact-count fast path applies) must still parse via the sentinel fallback.
+// With a bounded bytes.Reader the sentinel's terminating peek gets io.EOF
+// cleanly after the last arg.
+func TestStreamNonRegistryCall(t *testing.T) {
 	nonReg := ObjID{ObjNum: 99, UID: UID{Unique: 1, Time: 2, Count: 3}}
 	data := buildCall(nonReg, LookupOpIndex, RegistryInterfaceHash, buildTCString("x"))
 
-	_, err := FromStream(bytes.NewReader(data))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "only supports Registry")
+	tr, err := FromStream(bytes.NewReader(data))
+	require.NoError(t, err)
+	require.Len(t, tr.Messages, 1)
+	call, ok := tr.Messages[0].(*CallMessage)
+	require.True(t, ok)
+	require.False(t, call.ObjID.IsRegistry())
+	require.Len(t, call.ObjectArgs, 1)
+	// Decoder only fires for a valid Registry dispatch — non-Registry ObjID
+	// leaves call.Decoded nil even when the interface hash happens to match.
+	require.Nil(t, call.Decoded)
 }
 
-// TestStreamRejectsWrongInterfaceHash: even with Registry ObjID, a
-// mismatched interface hash means this isn't actually a Registry call.
-// Streaming must refuse.
-func TestStreamRejectsWrongInterfaceHash(t *testing.T) {
+// TestStreamWrongInterfaceHash: Registry ObjID but a bogus methodHash —
+// sentinel fallback parses the Call, and Decoded stays nil because the
+// Registry dispatch guard (ObjID + hash) doesn't match.
+func TestStreamWrongInterfaceHash(t *testing.T) {
 	const bogus int64 = 0x1234567890ABCDEF
 	data := buildCall(ObjID{}, LookupOpIndex, bogus, buildTCString("x"))
 
-	_, err := FromStream(bytes.NewReader(data))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "only supports Registry")
+	tr, err := FromStream(bytes.NewReader(data))
+	require.NoError(t, err)
+	require.Len(t, tr.Messages, 1)
+	call := tr.Messages[0].(*CallMessage)
+	require.Equal(t, int64(bogus), call.MethodHash)
+	require.Nil(t, call.Decoded)
+	require.Len(t, call.ObjectArgs, 1)
 }
 
-// TestStreamRejectsUnknownRegistryOp: Registry ObjID + correct hash but an
-// op-index outside [0..4]. Without a known arg count we refuse to guess.
-func TestStreamRejectsUnknownRegistryOp(t *testing.T) {
+// TestStreamUnknownRegistryOp: Registry ObjID + correct hash but op=99
+// (outside the stub's op table). registryArgCount returns false, so we fall
+// back to sentinel and still parse the payload cleanly.
+func TestStreamUnknownRegistryOp(t *testing.T) {
 	data := buildCall(ObjID{}, 99, RegistryInterfaceHash, buildTCString("x"))
 
-	_, err := FromStream(bytes.NewReader(data))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "known Registry op-indices")
+	tr, err := FromStream(bytes.NewReader(data))
+	require.NoError(t, err)
+	require.Len(t, tr.Messages, 1)
+	call := tr.Messages[0].(*CallMessage)
+	require.Equal(t, int32(99), call.Operation)
+	// Decoded keeps nil because registryDecoders has no entry for op=99.
+	require.Nil(t, call.Decoded)
+	require.Len(t, call.ObjectArgs, 1)
 }
 
-// TestStreamRejectsReturn: NormalReturn's 0-vs-1 payload depends on the
-// originating Call's return type; we have no way to know in a
-// direction-agnostic stream. Error explicitly rather than guess wrong.
-func TestStreamRejectsReturn(t *testing.T) {
-	data := buildReturn(NormalReturn, UID{Unique: 1, Time: 2, Count: 3}, nil)
+// TestStreamReturnWithPayload: ReturnData streaming via sentinel. A
+// NormalReturn with one payload TCContent parses, payload count is 1.
+func TestStreamReturnWithPayload(t *testing.T) {
+	uid := UID{Unique: 1, Time: 2, Count: 3}
+	data := buildReturn(NormalReturn, uid, buildTCString("result"))
 
-	_, err := FromStream(bytes.NewReader(data))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "does not support ReturnData")
-	require.Contains(t, err.Error(), "FromBytes")
+	tr, err := FromStream(bytes.NewReader(data))
+	require.NoError(t, err)
+	require.Len(t, tr.Messages, 1)
+	ret, ok := tr.Messages[0].(*ReturnMessage)
+	require.True(t, ok)
+	require.Equal(t, NormalReturn, ret.ReturnType)
+	require.NotNil(t, ret.Payload)
+}
+
+// TestStreamReturnVoid: a ReturnData with no payload (void method) — the
+// sentinel reads zero payload TCContents and terminates on io.EOF.
+func TestStreamReturnVoid(t *testing.T) {
+	uid := UID{Unique: 1, Time: 2, Count: 3}
+	data := buildReturn(NormalReturn, uid, nil)
+
+	tr, err := FromStream(bytes.NewReader(data))
+	require.NoError(t, err)
+	require.Len(t, tr.Messages, 1)
+	ret := tr.Messages[0].(*ReturnMessage)
+	require.Equal(t, NormalReturn, ret.ReturnType)
+	require.Nil(t, ret.Payload)
 }
 
 // TestStreamPingPingAckDgcAck: bounded-length frames the streaming parser


### PR DESCRIPTION
## Summary

- Drop `FromStream`'s Registry-only restriction: non-Registry `CallMessage` and `ReturnMessage` now parse in streaming mode via sentinel fallback. Registry Calls keep their exact-count fast path, so the common case still returns without peeking past the last arg.
- Add `rmi.Decoder` — an idiomatic frame-by-frame API (`NewDecoder` + `Opening` + `Next`) for live `net.Conn` consumers who want to apply `SetReadDeadline` between frames.
- Delete the `streaming bool` parameter chain (`parseTransmission` → `readMessage` → `readCall` / `readReturn` / `readCallArgs`). Each frame picks its arg strategy from its own header, not from the input source.

## Why

Before this change, any live-TCP consumer of a non-Registry remote — or any consumer of `ReturnMessage` — had to buffer the whole conversation and call `FromBytes`, which defeats the point of a streaming parser. The unified sentinel approach + per-frame Decoder API solves that without losing the Registry non-blocking fast path.

The one genuinely new tradeoff is documented up front: non-Registry Calls and Returns block on a terminating peek until the next frame arrives or the reader returns an error. That's protocol-inherent (JRMP has no length prefix inside Call/Return), and the Decoder's contract is to push deadline management up to the caller via `conn.SetReadDeadline`, same pattern mature HTTP/WebSocket servers use.

## Test plan

- [x] `go test ./...` — all 80+ existing tests pass, plus new coverage:
  - `TestStream{NonRegistryCall,WrongInterfaceHash,UnknownRegistryOp,ReturnWithPayload,ReturnVoid}` — replacements for the four old `TestStreamRejects*` tests
  - `TestDecoderFrameByFrame`, `TestDecoderSkipsOpeningWhenOmitted`, `TestDecoderOpeningTwiceErrors`, `TestDecoderOpeningAfterNextErrors`, `TestDecoderBareCaptureNoOpening`
  - **`TestDecoderRegistryCallReturnsWithoutPeek`** — feeds exact Registry Call bytes into an `io.Pipe` that is *never closed*; if the parser peeks past the last arg it deadlocks and a 2s timeout fires the failure. Proves the exact-count fast path.
  - **`TestDecoderNonRegistryCallBlocksOnSentinelPeek`** — asserts the sentinel peek *does* block while the pipe is open (150ms budget) and unblocks correctly once the writer closes. Documents the blocking contract.
- [x] `go vet ./...`
- [ ] `golangci-lint run` (local version too new for current config; CI will validate)
- [x] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)